### PR TITLE
fix the commands command finally

### DIFF
--- a/2006Redone Server/src/redone/integrations/discord/commands/Commands.java
+++ b/2006Redone Server/src/redone/integrations/discord/commands/Commands.java
@@ -9,7 +9,7 @@ public class Commands implements MessageCreateListener {
     public void onMessageCreate(MessageCreateEvent event) {
         Message message = event.getMessage();
         if (message.getContent().equalsIgnoreCase("::commands")) {
-            event.getChannel().sendMessage("```" +
+            event.getChannel().sendMessage("```fix" +
                     "::forum/::forums"
                     + System.lineSeparator() +
                     "::heatmap"


### PR DESCRIPTION
Fixes the commands command,
Was originally missing a double quote mark,
Then an extra back-tick got added,
Then more back-ticks were added,
Then the fix keyword was removed,
I've added back the fix keyword which will give the commands the yellow coloring 