### PR TITLE
Finally "Fix" Discordbot ::commands

### DIFF
--- a/2006Redone Server/src/redone/integrations/discord/commands/Commands.java
+++ b/2006Redone Server/src/redone/integrations/discord/commands/Commands.java
@@ -9,7 +9,8 @@ public class Commands implements MessageCreateListener {
     public void onMessageCreate(MessageCreateEvent event) {
         Message message = event.getMessage();
         if (message.getContent().equalsIgnoreCase("::commands")) {
-            event.getChannel().sendMessage("```" +
+            event.getChannel().sendMessage("```fix"
+                    + System.lineSeparator() +
                     "::forum/::forums"
                     + System.lineSeparator() +
                     "::heatmap"
@@ -25,7 +26,7 @@ public class Commands implements MessageCreateListener {
                     "::vote"
                     + System.lineSeparator() +
                     "::website/::site"
-            + "```");
+                    + "```");
         }
     }
 }


### PR DESCRIPTION
commit by @RedSparr0w 

Fixes the commands command,
Was originally missing a double quote mark,
Then an extra back-tick got added,
Then more back-ticks were added,
Then the fix keyword was removed,
I've added back the fix keyword which will give the commands the yellow coloring