### PR TITLE
fix black knights quest rewards

### DIFF
--- a/2006Redone Server/src/redone/game/content/quests/QuestRewards.java
+++ b/2006Redone Server/src/redone/game/content/quests/QuestRewards.java
@@ -144,12 +144,11 @@ public class QuestRewards {
 		client.cookAss = 3;
 	}
 	public static void blackKnightReward(Client client) {
-		QuestReward(client, "Black Knights' Fortress", "6 Quest Point", "5000 Coins", "10k Attack XP", "", "", "", 326);
+		QuestReward(client, "Black Knights' Fortress", "3 Quest Point", "2500 Coins", "", "", "", "", 0);
 		QUEST_NAME = "Black Knights' Fortress";
-		client.getItemAssistant().addItem(995, 5000);
-		client.getPlayerAssistant().addNormalExperienceRate(10000, client.playerAttack);
-		client.questPoints++;
-		client.getPlayerAssistant().sendFrame126("@gre@" + QUEST_NAME + "", 7333);
+		client.getItemAssistant().addItem(995, 2500);
+		client.questPoints += 3;
+		client.getPlayerAssistant().sendFrame126("@gre@" + QUEST_NAME + "", 7332);
 		client.blackKnight = 3;
 	}
 }


### PR DESCRIPTION
should reward 3 QP _(currently only gives 1, says it gives 5)_
should reward 2500 coins _(currently says and give 5000)_
should not reward attack exp _(currently says and gives 10,000)_
should not award any items _(currently gives a sardine?)_
using wrong id for frame

[from the wiki](https://oldschool.runescape.wiki/w/Black_Knights%27_Fortress):
![image](https://user-images.githubusercontent.com/7288322/67533437-6bbee000-f726-11e9-9e65-ab4d9538c1b9.png)
